### PR TITLE
Use one 'column-segs' and 'segment-syns' function for all synapse types

### DIFF
--- a/src/org/numenta/sanity/controls_ui.cljs
+++ b/src/org/numenta/sanity/controls_ui.cljs
@@ -568,7 +568,7 @@
              [:div.panel-body
               [:div "(selected column) "
                [:select {:field :list
-                         :id :distal-synapses.from}
+                         :id :distal-synapses.to}
                 [:option {:key :all} "all cell segments"]
                 [:option {:key :selected} "selected segment"]
                 [:option {:key :none} "none"]

--- a/src/org/numenta/sanity/main.cljs
+++ b/src/org/numenta/sanity/main.cljs
@@ -12,7 +12,7 @@
 
 ;;; ## Journal data
 
-(def into-journal (async/chan))
+(def into-journal (async/chan 65536))
 
 ;;; ## Viz data
 


### PR DESCRIPTION
Main changes:

- Use a cells -> segments -> synapses for all synapse types, even proximal.
  Now the client and server both use a single set of functions for all synapse
  types. data.cljc is now a lot prettier.
- Make the proximal synapse server API look very similar to distal/apical.
- Move proximal trace-back from the server to the client, so that all servers
  get it for free, and so the server has a simpler API, allowing clients to do
  what they want. Although it's slower to do this on the client. I think the
  real fix for this slowness is to support querying multiple columns at once
  rather than sending one message per column. I haven't started on this fix.
- Continue removing viz-options from messages. Send the syn-states instead.
  This is working toward the goal of being able to remove awareness of keywords
  from servers, among other things.

Also:

- Start storing basic bit info on the step, not waiting for inbits-cols data.
  The main reason is because when you set viz-options to draw proximal synapses
  to all active columns, you can't query for them until the inbits-cols message
  arrives. This was the pragmatic fix, rather than invalidating the proximal
  syns when the inbits-cols arrives. Also this solves the problem with the bits
  lagging behind the incoming steps in cases where the model is really fast.