### PR TITLE
Send strings, not keywords, across the network

### DIFF
--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -32,7 +32,7 @@ websocket. Every message arriving on the websocket is a string that contains a
 vector. The vector generally looks like:
 
 ~~~clojure
-`[target-id :put! msg]`
+`["put!" target-id msg]`
 ~~~
 
 Clients and servers send messages to each others' targets, usually by wrapping a
@@ -40,11 +40,10 @@ Clients and servers send messages to each others' targets, usually by wrapping a
 from. Clients and servers tell each other about their own target-ids, but the
 process needs to be jumpstarted somehow. The client needs to know about at least
 one server target a priori. This is sometimes hardcoded (the Sanity runner knows
-to expect an `:into-journal` and an `:into-sim` target) and other times is
-injected into a webpage (the Sanity notebook hosts an arbitrary number of
-journals in one webpage, so it generates a uniquely named equivelent to
-`:into-journal` on every `viz`). New targets are generated all the time and are
-sent inside of `msg`s.
+to expect a `journal` and a `simulation` target) and other times is injected
+into a webpage (the Sanity notebook hosts an arbitrary number of journals in one
+webpage, so it generates a uniquely named equivelent to `journal` on every
+`viz`). New targets are generated all the time and are sent inside of `msg`s.
 
 The `msg` is arbitrary large. It is often a vector containing a command and
 arguments, and other times it's a response to a specific request or

--- a/examples/cortical_io/org/numenta/sanity/cortical_io_demo.cljs
+++ b/examples/cortical_io/org/numenta/sanity/cortical_io_demo.cljs
@@ -161,7 +161,7 @@ fox eat something.
                (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
-                     (put! main/into-journal [:get-model model-id
+                     (put! main/into-journal ["get-model" model-id
                                               (marshal/channel out-c)])
                      (go
                        (reset! selected-htm (<! out-c)))))))
@@ -361,4 +361,4 @@ fox eat something.
   (reagent/render [main/sanity-app [model-tab] [world-pane] into-sim]
                   (dom/getElement "sanity-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
-  (put! into-sim [:run]))
+  (put! into-sim ["run"]))

--- a/examples/demos/org/numenta/sanity/demos/hotgym.cljs
+++ b/examples/demos/org/numenta/sanity/demos/hotgym.cljs
@@ -168,7 +168,7 @@
         out-c (async/chan)
         model-id (:model-id step)]
     (put! main/into-journal
-          [:consider-future model-id candidate (marshal/channel out-c true)])
+          ["consider-future" model-id candidate (marshal/channel out-c true)])
     (go
       (let [[[_ col-state-freqs]] (seq (<! out-c))]
         (swap! step->scores assoc-in [step consumption]
@@ -319,7 +319,7 @@
                          :let [out-c (async/chan)
                                model-id (:model-id step)]]
                    (put! main/into-journal
-                         [:decode-predictive-columns model-id
+                         ["decode-predictive-columns" model-id
                           :power-consumption @n-predictions
                           (marshal/channel out-c true)])
                    (when @try-boundaries?

--- a/examples/demos/org/numenta/sanity/demos/letters.cljs
+++ b/examples/demos/org/numenta/sanity/demos/letters.cljs
@@ -62,7 +62,7 @@ Chifung has a friend."))
                (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
-                     (put! main/into-journal [:get-model model-id
+                     (put! main/into-journal ["get-model" model-id
                                               (marshal/channel out-c true)])
                      (go
                        (reset! selected-htm (<! out-c)))))))

--- a/examples/demos/org/numenta/sanity/demos/notebook.cljs
+++ b/examples/demos/org/numenta/sanity/demos/notebook.cljs
@@ -45,7 +45,7 @@
         response-c (async/chan)]
     (swap! remote-target->chan assoc journal-target into-journal)
     (@pipe-to-remote-target! journal-target into-journal)
-    (put! into-journal [:get-steps (marshal/channel response-c true)])
+    (put! into-journal ["get-steps" (marshal/channel response-c true)])
     (go
       (let [[step-template all-steps :as r] (<! response-c)
             step-template (atom step-template)

--- a/examples/demos/org/numenta/sanity/demos/q_learning_1d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/q_learning_1d.cljs
@@ -156,7 +156,7 @@
                (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
-                     (put! main/into-journal [:get-model model-id
+                     (put! main/into-journal ["get-model" model-id
                                               (marshal/channel out-c true)])
                      (go
                        (reset! selected-htm (<! out-c)))))))

--- a/examples/demos/org/numenta/sanity/demos/q_learning_2d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/q_learning_2d.cljs
@@ -115,7 +115,7 @@
                (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
-                     (put! main/into-journal [:get-model model-id
+                     (put! main/into-journal ["get-model" model-id
                                               (marshal/channel out-c true)])
                      (go
                        (reset! selected-htm (<! out-c)))))))

--- a/examples/demos/org/numenta/sanity/demos/runner.cljs
+++ b/examples/demos/org/numenta/sanity/demos/runner.cljs
@@ -38,13 +38,13 @@
         into-journal main/into-journal
         pipe-to-remote-target! (remote/init ws-url)
         features (into #{} (map keyword) feature-list)]
-    (pipe-to-remote-target! :into-journal into-journal)
-    (pipe-to-remote-target! :into-sim (tap-c into-sim-mult))
+    (pipe-to-remote-target! "journal" into-journal)
+    (pipe-to-remote-target! "simulation" (tap-c into-sim-mult))
 
     (go-loop []
       (when-not (nil? (<! into-sim-eavesdrop))
         ;; Ensure the journal is still connected, resubscribing if needed.
-        (put! into-journal [:ping])
+        (put! into-journal ["ping"])
         (recur)))
 
     (reagent/render [main/sanity-app title nil

--- a/examples/demos/org/numenta/sanity/demos/simple_sentences.cljs
+++ b/examples/demos/org/numenta/sanity/demos/simple_sentences.cljs
@@ -49,7 +49,7 @@
                (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
-                     (put! main/into-journal [:get-model model-id
+                     (put! main/into-journal ["get-model" model-id
                                               (marshal/channel out-c true)])
                      (go
                        (reset! selected-htm (<! out-c)))))))

--- a/src/org/numenta/sanity/comportex/README.md
+++ b/src/org/numenta/sanity/comportex/README.md
@@ -5,14 +5,14 @@ The server runs a "simulation" and maintains a "journal".
 The server listens to two channels, one for the simulation and one for the journal. The client sends messages into these channels to control the simulation and to request / subscribe to content. The server responds by putting values on client-provided channels. To put a value v on a channel remotely, send
 
 ~~~clojure
-[target-id :put! v]
+["put!" target-id v]
 ~~~
 
 into the websocket. This `target-id` is provided by the client. The client sends similar messages to the server, e.g.
 
 ~~~clojure
 ;; 24601 and 24602 are target-ids
-[:into-journal :put! [:subscribe 40 24601 24602]]
+["put!" :into-journal [:subscribe 40 24601 24602]]
 ~~~
 
 This server doesn't serve HTM models directly to the client. It serves a description of "what to draw". It serves content. In other words, it's a webserver, not a database. The format of these "what to draw" descriptions is different for each command.

--- a/src/org/numenta/sanity/comportex/notebook.clj
+++ b/src/org/numenta/sanity/comportex/notebook.clj
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :as async]
             [cognitect.transit :as transit]
             [compojure.route :as route]
+            [org.numenta.sanity.bridge.marshalling :as marshal]
             [org.numenta.sanity.comportex.journal :as journal]
             [org.numenta.sanity.comportex.runner :as runner]
             [gorilla-renderable.core :as renderable]
@@ -18,7 +19,7 @@
 (defn transit-str
   [m]
   (let [out (ByteArrayOutputStream.)
-        writer (transit/writer out :json)]
+        writer (transit/writer out marshal/encoding)]
     (transit/write writer m)
     (.toString out)))
 

--- a/src/org/numenta/sanity/comportex/runner.clj
+++ b/src/org/numenta/sanity/comportex/runner.clj
@@ -18,8 +18,8 @@
          models-mult (async/mult models-in)
          connection-changes-c (async/chan)
          connection-changes-mult (async/mult connection-changes-c)
-         ch->mchannel (atom {:into-sim (marshal/channel into-sim)
-                             :into-journal (marshal/channel into-journal)})
+         ch->mchannel (atom {"simulation" (marshal/channel into-sim)
+                             "journal" (marshal/channel into-journal)})
          server (server-ws/start ch->mchannel connection-changes-c
                                  (assoc opts
                                         :http-handler (route/files "/")))]

--- a/src/org/numenta/sanity/controls_ui.cljs
+++ b/src/org/numenta/sanity/controls_ui.cljs
@@ -95,7 +95,7 @@
                          :let [old-spec (get-in prev-st path)
                                new-spec (get-in st path)]]
                    (when (not= old-spec new-spec)
-                     (put! into-sim [:set-spec path new-spec]))))))
+                     (put! into-sim ["set-spec" path new-spec]))))))
 
   (let [partypes (cljs.core/atom {})] ;; write-once cache
     (fn [step-template selection into-sim]
@@ -141,8 +141,8 @@
                                  (<! (async/timeout 100))
                                  (let [finished (async/chan)]
                                    (put! into-sim
-                                         [:restart (marshal/channel finished
-                                                                    true)])
+                                         ["restart" (marshal/channel finished
+                                                                     true)])
                                    (<! finished))))}
                   "Rebuild model"]
                  [:p.small "This will not reset, or otherwise alter, the input stream."]]
@@ -156,7 +156,7 @@
 (defn gather-col-state-history!
   [col-state-history step into-journal]
   (let [response-c (async/chan)]
-    (put! into-journal [:get-column-state-freqs
+    (put! into-journal ["get-column-state-freqs"
                         (:model-id step)
                         (marshal/channel response-c true)])
     (go
@@ -373,7 +373,8 @@
         [rgn-id lyr-id] (sel/layer sel1)]
     (when lyr-id
       (let [response-c (async/chan)]
-        (put! into-journal [:get-details-text model-id rgn-id lyr-id bit
+        (put! into-journal ["get-details-text" model-id (name rgn-id)
+                            (name lyr-id) bit
                             (marshal/channel response-c true)])
         (go
           (reset! text-response (<! response-c)))))))
@@ -614,7 +615,7 @@
         going? (atom false)
         subscriber-c (async/chan)]
 
-    (put! into-sim [:subscribe-to-status (marshal/channel subscriber-c)])
+    (put! into-sim ["subscribe-to-status" (marshal/channel subscriber-c)])
 
     (go-loop []
       (when-let [[g?] (<! subscriber-c)]
@@ -670,7 +671,7 @@
           [:li (when-not @going? {:class "hidden"})
            [:button.btn.btn-default.navbar-btn
             (cond-> {:type :button
-                     :on-click #(put! into-sim [:pause])
+                     :on-click #(put! into-sim ["pause"])
                      :style {:width "5em"}}
               (not @step-template) (assoc :disabled "disabled"))
             "Pause"]]
@@ -678,7 +679,7 @@
           [:li (when @going? {:class "hidden"})
            [:button.btn.btn-primary.navbar-btn
             (cond-> {:type :button
-                     :on-click #(put! into-sim [:run])
+                     :on-click #(put! into-sim ["run"])
                      :style {:width "5em"}}
               (not @step-template) (assoc :disabled "disabled"))
             "Run"]]
@@ -816,31 +817,31 @@
              [:ul.dropdown-menu {:role "menu"}
               [:li [:a {:href "#"
                         :on-click (fn []
-                                    (put! into-sim [:set-step-ms 0])
+                                    (put! into-sim ["set-step-ms" 0])
                                     (swap! viz-options assoc-in
                                            [:drawing :anim-every] 1))}
                     "max sim speed"]]
               [:li [:a {:href "#"
                         :on-click (fn []
-                                    (put! into-sim [:set-step-ms 0])
+                                    (put! into-sim ["set-step-ms" 0])
                                     (swap! viz-options assoc-in
                                            [:drawing :anim-every] 100))}
                     "max sim speed, draw every 100 steps"]]
               [:li [:a {:href "#"
                         :on-click (fn []
-                                    (put! into-sim [:set-step-ms 250])
+                                    (put! into-sim ["set-step-ms" 250])
                                     (swap! viz-options assoc-in
                                            [:drawing :anim-every] 1))}
                     "limit to 4 steps/sec."]]
               [:li [:a {:href "#"
                         :on-click (fn []
-                                    (put! into-sim [:set-step-ms 500])
+                                    (put! into-sim ["set-step-ms" 500])
                                     (swap! viz-options assoc-in
                                            [:drawing :anim-every] 1))}
                     "limit to 2 steps/sec."]]
               [:li [:a {:href "#"
                         :on-click (fn []
-                                    (put! into-sim [:set-step-ms 1000])
+                                    (put! into-sim ["set-step-ms" 1000])
                                     (swap! viz-options assoc-in
                                            [:drawing :anim-every] 1))}
                     "limit to 1 step/sec."]]]])

--- a/src/org/numenta/sanity/main.cljs
+++ b/src/org/numenta/sanity/main.cljs
@@ -28,7 +28,7 @@
 (defn subscribe-to-steps! []
   (let [steps-c (async/chan)
         response-c (async/chan)]
-    (put! into-journal [:subscribe (marshal/channel steps-c)
+    (put! into-journal ["subscribe" (marshal/channel steps-c)
                         (marshal/channel response-c true)])
     (go
       ;; Get the template before getting any steps.
@@ -42,7 +42,7 @@
                   :path [:regions region-key layer-id]}]))
       (add-watch capture-options ::push-to-server
                  (fn [_ _ _ opts]
-                   (put! into-journal [:set-capture-options opts])))
+                   (put! into-journal ["set-capture-options" opts])))
 
       (loop []
         (when-let [step (<! steps-c)]

--- a/src/org/numenta/sanity/plots.cljs
+++ b/src/org/numenta/sanity/plots.cljs
@@ -307,8 +307,8 @@
     (if-let [model-id (:model-id sel)]
       (let [response-c (async/chan)]
         (put! into-journal
-              [:get-cell-excitation-data model-id region-key layer-id bit
-               (marshal/channel response-c true)])
+              ["get-cell-excitation-data" model-id (name region-key)
+               (name layer-id) bit (marshal/channel response-c true)])
         (go
           (reset! excitation-data (<! response-c))))
       (reset! excitation-data {}))))
@@ -728,7 +728,7 @@
   (when-let [[region layer] (sel/layer sel)]
     (let [model-id (:model-id sel)
           response-c (async/chan)]
-      (put! into-journal [:get-transitions-data
+      (put! into-journal ["get-transitions-data"
                           model-id region layer cell-sdr-counts
                           (marshal/channel response-c true)])
       response-c)))
@@ -799,7 +799,7 @@
         :let [response-c (async/chan)
               model-id (:model-id step)]]
     (go
-      (put! into-journal [:get-cells-by-state model-id
+      (put! into-journal ["get-cells-by-state" model-id
                           region layer
                           (marshal/channel response-c true)])
       (let [cells-by-state (<! response-c)

--- a/src/org/numenta/sanity/util.cljc
+++ b/src/org/numenta/sanity/util.cljc
@@ -1,6 +1,7 @@
 (ns org.numenta.sanity.util
   (:require #?(:clj [clojure.core.async :as async]
-               :cljs [cljs.core.async :as async])))
+               :cljs [cljs.core.async :as async])
+            [clojure.walk :refer [postwalk]]))
 
 (defn tap-c
   [mult]
@@ -14,3 +15,25 @@
               (keep-indexed (fn [i v]
                               (when (pred v)
                                 i))))))
+
+(defn keywordize-keys*
+  "Recursively transforms all map keys from strings to keywords.
+  Like `clojure.walk/keywordize-keys`, but does not transform records."
+  [m]
+  (let [f (fn [[k v]] (if (string? k) [(keyword k) v] [k v]))]
+    ;; only apply to maps, and don't apply to records
+    (postwalk (fn [x] (if (and (map? x) (not (record? x)))
+                        (into {} (map f x))
+                        x))
+              m)))
+
+(defn stringify-keys*
+  "Recursively transforms all map keys from keywords to strings.
+  Like `clojure.walk/stringify-keys`, but does not transform records."
+  [m]
+  (let [f (fn [[k v]] (if (keyword? k) [(name k) v] [k v]))]
+    ;; only apply to maps, and don't apply to records
+    (postwalk (fn [x] (if (and (map? x) (not (record? x)))
+                        (into {} (map f x))
+                        x))
+              m)))


### PR DESCRIPTION
The main goal for this change is to make it where servers aren't inconvenienced
by the fact that Sanity is written in ClojureScript.

The overall approach: Clojure endpoints (e.g. the Sanity client and the
Comportex server) will use keywords internally. They use stringify-keys and
keywordize-keys, so all map keys just work. Some manual switching between
keywords and strings does happen because there are values that appear as both
keys and message params (namely, region IDs and layer IDs).

This change required me to form a point of view on keywords. I'll blog about it
here. :)

Clojure untangles a "keyword" type from the "string" type. The initial reason
for having a dedicated "keyword" is that it can do magic to support super-fast
equality checks. With keywords, a central instance table is used, so that two
equal-valued keywords are guaranteed to use the same instance.

In Clojure, equality checks are super fast if the references are equal (=>
values equal). They're pretty fast when the references are different and the
cached hashes are different (=> values not equal), just requiring a one-time
hash check per instance. Equality checks are much slower when the values are the
same but the references are non-equal. Then equality checking requires comparing
the entire value every time.

For keywords, you only need the reference check.

During map lookup, the key's hash is used to reach a leaf node which contains a
list of keys with colliding hashes, and then the key is compared to each of
these keys to check for a match. So, fast equality checking is a good
thing. This kind of thing is possible because keywords are untangled from
strings, so this central instance table overhead doesn't apply to strings.

So the above explains why keywords are a good idea in general: for perf. But why
should we use them on Sanity endpoints built in Clojure? Will it actually be
good for performance, since it involves translating every sent and received
message (with 'stringify-keys' and 'keywordize-keys')?

Two answers:

- Our reason for keywordizing the strings isn't for perf. It's because the
  Clojure language itself embraces keywords. Clojure favors keywords over
  strings as map keys for perf, and the language then adds additional reasons to
  use keywords (e.g. map destructuring). We want keywords for those reasons.
- We are free to fix this perf issue. We could use custom Transit handlers for
  Maps which translate the keys between keywords and strings. I didn't do this,
  but we have this in our back pocket.

Other notes:

- Similar to my other client-server changes, the in-browser Comportex is largely
  unaffected. It doesn't do the stringify + keywordize.
- Similar to my other client-server changes, this is the initial big
  change. With this new line drawn, over time we might improve some of this
  keyword/string back and forth, e.g. with region IDs
- I banged my head against the wall repeatedly while chasing down an issue that
  ended up being a Transit bug.