### PR TITLE
Split "subscribe" into 3 messages. Fix and improve model resetting.

### DIFF
--- a/examples/demos/org/numenta/sanity/demos/coordinates_2d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/coordinates_2d.cljs
@@ -8,7 +8,7 @@
             [org.numenta.sanity.plots-canvas :as plt]
             [org.numenta.sanity.bridge.browser :as server]
             [org.numenta.sanity.comportex.data :as data]
-            [org.numenta.sanity.util :as utilv]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -142,7 +142,8 @@
       (reset! model (demo/n-region-model (:n-regions @config)))
       (if init?
         (server/init model world-c main/into-journal into-sim)
-        (reset! main/step-template (data/step-template-data @model)))
+        (reset! main/network-shape (translate-network-shape
+                                    (data/network-shape @model))))
       (when init?
         (feed-world!)))))
 

--- a/examples/demos/org/numenta/sanity/demos/cortical_io.cljs
+++ b/examples/demos/org/numenta/sanity/demos/cortical_io.cljs
@@ -13,7 +13,7 @@
             [org.numenta.sanity.bridge.browser :as server]
             [org.numenta.sanity.bridge.marshalling :as marshal]
             [org.numenta.sanity.comportex.data :as data]
-            [org.numenta.sanity.util :as utilv]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
@@ -250,7 +250,8 @@ fox eat something.
                      {:input sensor}))
       (if init?
         (server/init model world-c main/into-journal into-sim)
-        (reset! main/step-template (data/step-template-data @model)))
+        (reset! main/network-shape (translate-network-shape
+                                    (data/network-shape @model))))
       (swap! config assoc :have-model? true))))
 
 (def config-template

--- a/examples/demos/org/numenta/sanity/demos/fixed_seqs.cljs
+++ b/examples/demos/org/numenta/sanity/demos/fixed_seqs.cljs
@@ -8,7 +8,7 @@
             [org.numenta.sanity.plots-canvas :as plt]
             [org.numenta.sanity.bridge.browser :as server]
             [org.numenta.sanity.comportex.data :as data]
-            [org.numenta.sanity.util :as utilv]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -80,7 +80,8 @@
       (reset! model (demo/n-region-model (:n-regions @config)))
       (if init?
         (server/init model world-c main/into-journal into-sim)
-        (reset! main/step-template (data/step-template-data @model)))
+        (reset! main/network-shape (translate-network-shape
+                                    (data/network-shape @model))))
       (when init?
         (async/onto-chan world-c (demo/input-seq) false)))))
 

--- a/examples/demos/org/numenta/sanity/demos/hotgym.cljs
+++ b/examples/demos/org/numenta/sanity/demos/hotgym.cljs
@@ -6,6 +6,7 @@
             [org.numenta.sanity.demos.comportex-common :refer [all-features]]
             [org.numenta.sanity.main :as main]
             [org.numenta.sanity.comportex.data :as data]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [org.numenta.sanity.viz-canvas :as viz]
             [goog.dom :as dom]
             [goog.net.XhrIo :as XhrIo]
@@ -554,7 +555,8 @@
                                 " failed. " (.. e -target getStatus) " - "
                                 (.. e -target getStatusText))))))
           (server/init model world-c main/into-journal into-sim))
-        (reset! main/step-template (data/step-template-data @model))))))
+        (reset! main/network-shape (translate-network-shape
+                                    (data/network-shape @model)))))))
 
 (defn model-tab
   []

--- a/examples/demos/org/numenta/sanity/demos/letters.cljs
+++ b/examples/demos/org/numenta/sanity/demos/letters.cljs
@@ -8,7 +8,7 @@
             [org.numenta.sanity.bridge.browser :as server]
             [org.numenta.sanity.bridge.marshalling :as marshal]
             [org.numenta.sanity.comportex.data :as data]
-            [org.numenta.sanity.util :as utilv]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
@@ -92,7 +92,8 @@ Chifung has a friend."))
       (reset! model (demo/n-region-model n-regions demo/spec))
       (if init?
         (server/init model world-c main/into-journal into-sim)
-        (reset! main/step-template (data/step-template-data @model))))))
+        (reset! main/network-shape (translate-network-shape
+                                    (data/network-shape @model)))))))
 
 (defn immediate-key-down!
   [e]

--- a/examples/demos/org/numenta/sanity/demos/q_learning_1d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/q_learning_1d.cljs
@@ -9,7 +9,7 @@
             [org.numenta.sanity.bridge.browser :as server]
             [org.numenta.sanity.bridge.marshalling :as marshal]
             [org.numenta.sanity.comportex.data :as data]
-            [org.numenta.sanity.util :as utilv]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -218,7 +218,8 @@
         (if init?
           (server/init model world-c main/into-journal into-sim
                        (demo/htm-step-with-action-selection world-c))
-          (reset! main/step-template (data/step-template-data @model)))
+          (reset! main/network-shape (translate-network-shape
+                                      (data/network-shape @model))))
         ;; seed input
         (put! world-c demo/initial-inval)))))
 

--- a/examples/demos/org/numenta/sanity/demos/q_learning_2d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/q_learning_2d.cljs
@@ -10,7 +10,7 @@
             [org.numenta.sanity.bridge.browser :as server]
             [org.numenta.sanity.bridge.marshalling :as marshal]
             [org.numenta.sanity.comportex.data :as data]
-            [org.numenta.sanity.util :as utilv]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -179,7 +179,8 @@
         (if init?
           (server/init model world-c main/into-journal into-sim
                        (demo/htm-step-with-action-selection world-c))
-          (reset! main/step-template (data/step-template-data @model)))
+          (reset! main/network-shape (translate-network-shape
+                                      (data/network-shape @model))))
         (put! world-c demo/initial-inval)))))
 
 (def config-template

--- a/examples/demos/org/numenta/sanity/demos/second_level_motor.cljs
+++ b/examples/demos/org/numenta/sanity/demos/second_level_motor.cljs
@@ -8,7 +8,7 @@
             [org.numenta.sanity.demos.sensorimotor-1d :refer [draw-eye]]
             [org.numenta.sanity.bridge.browser :as server]
             [org.numenta.sanity.comportex.data :as data]
-            [org.numenta.sanity.util :as utilv]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -149,7 +149,8 @@
           (server/init model world-c main/into-journal into-sim
                        (demo/htm-step-with-action-selection world-c
                                                             control-c))
-          (reset! main/step-template (data/step-template-data @model)))
+          (reset! main/network-shape (translate-network-shape
+                                      (data/network-shape @model))))
         ;; seed input
         (let [sentences (demo/parse-sentences (:text @config))]
           (put! world-c (demo/initial-inval sentences)))))))

--- a/examples/demos/org/numenta/sanity/demos/sensorimotor_1d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/sensorimotor_1d.cljs
@@ -7,7 +7,7 @@
             [org.numenta.sanity.plots-canvas :as plt]
             [org.numenta.sanity.bridge.browser :as server]
             [org.numenta.sanity.comportex.data :as data]
-            [org.numenta.sanity.util :as utilv]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -168,7 +168,8 @@
       (reset! model (demo/n-region-model (:n-regions @config)))
       (if init?
         (server/init model world-c main/into-journal into-sim)
-        (reset! main/step-template (data/step-template-data @model))))))
+        (reset! main/network-shape (translate-network-shape
+                                    (data/network-shape @model)))))))
 
 (def config-template
   [:div

--- a/examples/demos/org/numenta/sanity/demos/simple_sentences.cljs
+++ b/examples/demos/org/numenta/sanity/demos/simple_sentences.cljs
@@ -8,7 +8,7 @@
             [org.numenta.sanity.bridge.browser :as server]
             [org.numenta.sanity.bridge.marshalling :as marshal]
             [org.numenta.sanity.comportex.data :as data]
-            [org.numenta.sanity.util :as utilv]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
@@ -81,7 +81,8 @@
       (reset! model (demo/n-region-model n-regions demo/spec))
       (if init?
         (server/init model world-c main/into-journal into-sim)
-        (reset! main/step-template (data/step-template-data @model))))))
+        (reset! main/network-shape (translate-network-shape
+                                    (data/network-shape @model)))))))
 
 (defn send-text!
   []

--- a/src/org/numenta/sanity/comportex/data.cljc
+++ b/src/org/numenta/sanity/comportex/data.cljc
@@ -256,7 +256,7 @@
               wc)]
     (core/cell-excitation-breakdowns htm prior-htm rgn-id lyr-id wc+)))
 
-(defn step-template-data
+(defn network-shape
   [htm]
   (let [sense-keys (core/sense-keys htm)]
     {"senses" (->> (map vector (range) sense-keys)

--- a/src/org/numenta/sanity/comportex/journal.cljc
+++ b/src/org/numenta/sanity/comportex/journal.cljc
@@ -112,19 +112,23 @@
           "get-steps"
           (let [[{response-c :ch}] xs]
             (put! response-c
-                  [(data/step-template-data @current-model)
-                   (->> (map make-step @model-steps (drop @steps-offset
-                                                          (range)))
-                        vec)]))
+                  (->> (map make-step @model-steps (drop @steps-offset
+                                                         (range)))
+                       vec)))
 
           "subscribe"
-          (let [[steps-mchannel {response-c :ch}] xs]
+          (let [[steps-mchannel] xs]
             (async/tap steps-mult (:ch steps-mchannel))
             (swap! client-info assoc :steps-mchannel steps-mchannel)
-            (println "JOURNAL: Client subscribed to steps.")
-            (put! response-c
-                  [(data/step-template-data @current-model)
-                   (stringify-keys @capture-options)]))
+            (println "JOURNAL: Client subscribed to steps."))
+
+          "get-network-shape"
+          (let [[{response-c :ch}] xs]
+            (put! response-c (data/network-shape @current-model)))
+
+          "get-capture-options"
+          (let [[{response-c :ch}] xs]
+            (put! response-c (stringify-keys @capture-options)))
 
           "set-capture-options"
           (let [[co] xs]

--- a/src/org/numenta/sanity/main.cljs
+++ b/src/org/numenta/sanity/main.cljs
@@ -4,6 +4,7 @@
             [org.numenta.sanity.helpers :as helpers :refer [window-resize-listener]]
             [org.numenta.sanity.selection :as sel]
             [org.numenta.sanity.viz-canvas :as viz]
+            [org.numenta.sanity.util :refer [translate-network-shape]]
             [reagent.core :as reagent :refer [atom]]
             [cljs.core.async :as async :refer [chan put! <!]]
             [clojure.walk :refer [keywordize-keys stringify-keys]])
@@ -18,7 +19,7 @@
 ;;; ## Viz data
 
 (def steps (atom []))
-(def step-template (atom nil))
+(def network-shape (atom nil))
 (def selection (atom sel/blank-selection))
 (def capture-options (atom nil))
 (def viz-options (atom viz/default-viz-options))
@@ -33,40 +34,25 @@
 (defn subscribe-to-steps! []
   (let [steps-c (async/chan)
         response-c (async/chan)]
-    (put! into-journal ["subscribe" (marshal/channel steps-c)
-                        (marshal/channel response-c true)])
+    (put! into-journal ["get-network-shape" (marshal/channel response-c true)])
     (go
-      ;; Get the template before getting any steps.
-      (let [[st co] (<! response-c)
-            ;; keywordize the template, but don't mangle layer / sense IDs
-            {regions "regions" senses "senses"} st]
-        (reset! step-template
-                {:regions (into {}
-                                (for [[rgn-id rgn] regions]
-                                  [rgn-id
-                                   (into {}
-                                         (for [[lyr-id lyr] rgn]
-                                           [lyr-id (keywordize-keys lyr)]))]))
-                 :senses (into {}
-                               (for [[sense-id sense] senses]
-                                 [sense-id (keywordize-keys sense)]))})
-        (reset! capture-options (keywordize-keys co)))
-      (let [[region-key rgn] (-> @step-template :regions seq first)
+      (reset! network-shape (translate-network-shape (<! response-c)))
+      (put! into-journal ["subscribe" (marshal/channel steps-c)])
+      (let [[region-key rgn] (-> @network-shape :regions seq first)
             layer-id (-> rgn keys first)]
         (reset! selection
                 [{:dt 0
                   :path [:regions region-key layer-id]}]))
-      (add-watch capture-options ::push-to-server
-                 (fn [_ _ _ opts]
-                   (put! into-journal ["set-capture-options"
-                                       (stringify-keys opts)])))
-
       (loop []
         (when-let [step (<! steps-c)]
-          (let [step* (keywordize-keys step)
+          (let [step* (-> step
+                          keywordize-keys
+                          (assoc :network-shape @network-shape))
                 keep-steps (:keep-steps @capture-options)
-                [kept dropped] (split-at keep-steps
-                                         (cons step* @steps))]
+                steps* (cons step* @steps)
+                [kept dropped] (if keep-steps
+                                 (split-at keep-steps steps*)
+                                 [steps* nil])]
             (reset! steps kept)
             (put! into-viz [:drop-steps-data dropped]))
           (recur))))
@@ -110,13 +96,13 @@
          world-pane]
         [:div.col-sm-9.col-lg-10 {:style {:overflow "auto"}}
          [window-resize-listener size-invalidates-c]
-         [viz/viz-canvas nil steps selection step-template viz-options
+         [viz/viz-canvas nil steps selection network-shape viz-options
           into-viz into-sim into-journal]]]])))
 
 (defn sanity-app
   [title model-tab world-pane features into-sim]
   [cui/sanity-app title model-tab [main-pane world-pane into-sim]
-   features capture-options viz-options selection steps step-template
+   features capture-options viz-options selection steps network-shape
    viz/state-colors into-viz into-sim into-journal debug-data])
 
 ;;; ## Exported helpers

--- a/src/org/numenta/sanity/util.cljc
+++ b/src/org/numenta/sanity/util.cljc
@@ -1,7 +1,7 @@
 (ns org.numenta.sanity.util
   (:require #?(:clj [clojure.core.async :as async]
                :cljs [cljs.core.async :as async])
-            [clojure.walk :refer [postwalk]]))
+            [clojure.walk :refer [keywordize-keys]]))
 
 (defn tap-c
   [mult]
@@ -15,3 +15,17 @@
               (keep-indexed (fn [i v]
                               (when (pred v)
                                 i))))))
+
+(defn translate-network-shape
+  [n-shape-from-server]
+  ;; keywordize the network-shape, but don't mangle layer / sense IDs
+  (let [{regions "regions" senses "senses"} n-shape-from-server]
+    {:regions (into {}
+                    (for [[rgn-id rgn] regions]
+                      [rgn-id
+                       (into {}
+                             (for [[lyr-id lyr] rgn]
+                               [lyr-id (keywordize-keys lyr)]))]))
+     :senses (into {}
+                   (for [[sense-id sense] senses]
+                     [sense-id (keywordize-keys sense)]))}))


### PR DESCRIPTION
Also rename the "step template" to the "network shape". The previous name
reflected my old design where each step got merged with its fetched data.

We now keywordize parts of the network shape when it arrives. Add this treatment
to the demos, unbreaking resets.

Also make the viz-canvas stop using the up-to-date network shape when fetching
bits. Instead, assoc the network shape onto the step so that we don't do
anything goofy after adding more regions and then selecting an old
step. Regardless of how important resetting is, this is elegant. Note that we
still do goofy things with segments if you select an old bit in a newly created
region.