### PR TITLE
The "seg-selector": making synapse / segment messages more powerful

### DIFF
--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -332,7 +332,6 @@ Synapses by state
     'active': [
         {
             'src-id': 'mySense1',
-            'syn-state': 'active',
             'src-col': 48,
             'perm': 0.4,
             'src-dt' 1,
@@ -340,7 +339,6 @@ Synapses by state
         {
             'src-id': 'myRegion1',
             'src-lyr': 'myLayer1',
-            'syn-state': 'active',
             'src-col': 23,
             'perm': 0.3,
             'src-dt' 1,

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -13,12 +13,12 @@ _(This page is currently a draft / dumping ground.)_
     - ["get-network-shape"](#get-network-shape)
     - ["get-capture-options"](#get-capture-options)
     - ["set-capture-options"](#set-capture-options)
-    - ["get-column-apical-segments"](#get-column-apical-segments)
-    - ["get-column-distal-segments"](#get-column-distal-segments)
-    - ["get-column-proximal-segments"](#get-column-proximal-segments)
-    - ["get-apical-segment-synapses"](#get-apical-segment-synapses)
-    - ["get-distal-segment-synapses"](#get-distal-segment-synapses)
-    - ["get-proximal-segment-synapses"](#get-proximal-segment-synapses)
+    - ["get-apical-segments"](#get-apical-segments)
+    - ["get-distal-segments"](#get-distal-segments)
+    - ["get-proximal-segments"](#get-proximal-segments)
+    - ["get-apical-synapses"](#get-apical-synapses)
+    - ["get-distal-synapses"](#get-distal-synapses)
+    - ["get-proximal-synapses"](#get-proximal-synapses)
     - ["get-column-state-freqs"](#get-column-state-freqs)
     - ["get-column-cells"](#get-column-cells)
     - ["get-layer-bits"](#get-layer-bits)
@@ -248,22 +248,27 @@ disconnects.
 
 #### Get apical/distal/proximal segments
 
-<a name="get-column-apical-segments" />
-<a name="get-column-distal-segments" />
-<a name="get-column-proximal-segments" />
+<a name="get-apical-segments" />
+<a name="get-distal-segments" />
+<a name="get-proximal-segments" />
 
 **Messages:**
 
-- `"get-column-apical-segments"`
-- `"get-column-distal-segments"`
-- `"get-column-proximal-segments"`
+- `"get-apical-segments"`
+- `"get-distal-segments"`
+- `"get-proximal-segments"`
 
 **Parameters:**
 
 - `snapshot_id`
 - `region_id`
 - `layer_id`
-- `column`
+- `segment_selector`
+  - Examples:
+    - `[]` = none
+    - `[1, 7]` = all segments for columns 1, 7
+    - `{1: [2]}` = all segments for column 1, cell 2
+    - `{1: {2: [3, 4]}}` = the third and fourth segments on column 1, cell 2
 - `response_channel_marshal`
 
 **Response:**
@@ -290,24 +295,27 @@ index.
 
 #### Get apical/distal/proximal synapses
 
-<a name="get-apical-segment-synapses" />
-<a name="get-distal-segment-synapses" />
-<a name="get-proximal-segment-synapses" />
+<a name="get-apical-synapses" />
+<a name="get-distal-synapses" />
+<a name="get-proximal-synapses" />
 
 **Messages:**
 
-- `"get-apical-segment-synapses"`
-- `"get-distal-segment-synapses"`
-- `"get-proximal-segment-synapses"`
+- `"get-apical-synapses"`
+- `"get-distal-synapses"`
+- `"get-proximal-synapses"`
 
 **Parameters:**
 
 - `snapshot_id`
 - `region_id`
 - `layer_id`
-- `column`
-- `cell_index` the index within the column
-- `segment_index`the index within the cell
+- `segment_selector`
+  - Examples:
+    - `[]` = none
+    - `[1, 7]` = all synapses for columns 1, 7
+    - `{1: [2]}` = all synapses for column 1, cell 2
+    - `{1: {2: [3, 4]}}` = all synapses on the third and fourth segments on column 1, cell 2
 - `synapse_states` a set potentially containing:
   - `"active"`
   - `"inactive-syn"`

--- a/src/org/numenta/sanity/comportex/journal.cljc
+++ b/src/org/numenta/sanity/comportex/journal.cljc
@@ -259,49 +259,52 @@
                                        (p/winner-cells lyr))})
                     (id-missing-response id steps-offset))))
 
-          "get-column-apical-segments"
-          (let [[id rgn-id lyr-id col {response-c :ch}] xs]
+          "get-apical-segments"
+          (let [[id rgn-id lyr-id seg-selector {response-c :ch}] xs]
             (put! response-c
                   (if-let [[prev-htm htm] (find-model-pair id)]
-                    (data/column-segs htm prev-htm rgn-id lyr-id col :apical)
+                    (data/query-segs htm prev-htm rgn-id lyr-id seg-selector
+                                     :apical)
                     (id-missing-response id steps-offset))))
 
-          "get-column-distal-segments"
-          (let [[id rgn-id lyr-id col {response-c :ch}] xs]
+          "get-distal-segments"
+          (let [[id rgn-id lyr-id seg-selector {response-c :ch}] xs]
             (put! response-c
                   (if-let [[prev-htm htm] (find-model-pair id)]
-                    (data/column-segs htm prev-htm rgn-id lyr-id col :distal)
+                    (data/query-segs htm prev-htm rgn-id lyr-id seg-selector
+                                     :distal)
                     (id-missing-response id steps-offset))))
 
-          "get-column-proximal-segments"
-          (let [[id rgn-id lyr-id col {response-c :ch}] xs]
+          "get-proximal-segments"
+          (let [[id rgn-id lyr-id seg-selector {response-c :ch}] xs]
             (put! response-c
                   (if-let [[prev-htm htm] (find-model-pair id)]
-                    (data/column-segs htm prev-htm rgn-id lyr-id col :proximal)
+                    (data/query-segs htm prev-htm rgn-id lyr-id seg-selector
+                                     :proximal)
                     (id-missing-response id steps-offset))))
 
-          "get-apical-segment-synapses"
-          (let [[id rgn-id lyr-id col ci si syn-states {response-c :ch}] xs]
+          "get-apical-synapses"
+          (let [[id rgn-id lyr-id seg-selector syn-states {response-c :ch}] xs]
             (put! response-c
                   (if-let [[prev-htm htm] (find-model-pair id)]
-                    (data/segment-syns htm prev-htm rgn-id lyr-id col ci si
-                                       syn-states :apical)
+                    (data/query-syns htm prev-htm rgn-id lyr-id seg-selector
+                                     syn-states :apical)
                     (id-missing-response id steps-offset))))
 
-          "get-distal-segment-synapses"
-          (let [[id rgn-id lyr-id col ci si syn-states {response-c :ch}] xs]
+          "get-distal-synapses"
+          (let [[id rgn-id lyr-id seg-selector syn-states {response-c :ch}] xs]
             (put! response-c
                   (if-let [[prev-htm htm] (find-model-pair id)]
-                    (data/segment-syns htm prev-htm rgn-id lyr-id col ci si
-                                       syn-states :distal)
+                    (data/query-syns htm prev-htm rgn-id lyr-id seg-selector
+                                     syn-states :distal)
                     (id-missing-response id steps-offset))))
 
-          "get-proximal-segment-synapses"
-          (let [[id rgn-id lyr-id col ci si syn-states {response-c :ch}] xs]
+          "get-proximal-synapses"
+          (let [[id rgn-id lyr-id seg-selector syn-states {response-c :ch}] xs]
             (put! response-c
                   (if-let [[prev-htm htm] (find-model-pair id)]
-                    (data/segment-syns htm prev-htm rgn-id lyr-id col ci si
-                                       syn-states :proximal)
+                    (data/query-syns htm prev-htm rgn-id lyr-id seg-selector
+                                     syn-states :proximal)
                     (id-missing-response id steps-offset))))
 
           "get-details-text"


### PR DESCRIPTION
Sometimes we want to query for synapses on multiple columns, and it's slow to do
it one column at a time. The API ought to allow for batch queries.

Instead of patching batch queries on top, e.g. by making messages take in a list
of columns, this change solves the general problem. Fundamentally, we already
were serving segments / synapses in batches, just in a hardcoded way -- by
column, or by segment. This change gets rid of the hardcode. The sender can now
create advanced column / cell / segment selectors to specify what it wants.

I like that the API no longer feels like it was designed around Sanity's UI.

In cases where we query lots of columns / segments, using these batch queries is
a nice perf win, bringing us roughly back up to where we were when the server
did all the fetch logic.