### PR TITLE
lay out 3D topologies as stacked 2D images.

### DIFF
--- a/src/org/numenta/sanity/viz_layouts.cljs
+++ b/src/org/numenta/sanity/viz_layouts.cljs
@@ -381,14 +381,16 @@
     (case display-mode
       :one-d (grid-1d-layout (topology/one-d-topology n-elements)
                              top left opts inbits?)
-      :two-d (let [[width height] (if (= 2 (count dims))
-                                    dims ;; keep actual topology if possible
-                                    (let [w (-> (Math/sqrt n-elements)
-                                                Math/ceil
-                                                (min 20))]
-                                      [w (-> n-elements
-                                             (/ w)
-                                             Math/ceil)]))]
+      :two-d (let [[width height] (case (count dims)
+                                    2 dims ;; keep actual topology if possible
+                                    1 (let [w (-> (Math/sqrt n-elements)
+                                                  Math/ceil
+                                                  (min 20))]
+                                        [w (-> n-elements
+                                               (/ w)
+                                               Math/ceil)])
+                                    3 (let [[w h d] dims]
+                                        [w (* h d)]))]
                (grid-2d-layout n-elements (topology/two-d-topology width height)
                                top left opts inbits?)))))
 


### PR DESCRIPTION
lay out 3D topologies as stacked 2D images (concatenated vertically).

It is also sometimes desirable to lay out 3D "stacked images" by interspersing bits from the multiple stacks at the corresponding position, so you can see how they line up. That could be done as an option but would require changing the display order of bits.
